### PR TITLE
Fix temperature support check

### DIFF
--- a/configs/telegraf.conf
+++ b/configs/telegraf.conf
@@ -31,5 +31,5 @@
 #   command = "sh /usr/lib/telegraf/edgeos.sh --firmware"
 #   data_format = "influx"
 #
-#   interval = "1d"
+#   interval = "24h"
 #

--- a/plugins/edgeos.sh
+++ b/plugins/edgeos.sh
@@ -98,13 +98,15 @@ edgeos_power() {
 edgeos_temperature() {
     temperature_info=$(sudo /usr/sbin/ubnt-hal getTemp | tail -n +2 | head -n -1)
 
-    if ! echo "$temperature_info" | grep "is not supported on this platform"; then
+    if ! [ -z "$temperature_info" ]; then
         echo "$temperature_info" | while read -r line; do
             temperature_info_sensor=$(echo "$line" | cut -d ':' -f 1 | sed 's/ /\\ /')
             temperature_info_value=$(echo "$line" | cut -d ':' -f 2 | cut -d ' ' -f 1)
 
             echo "edgeos_temperature,sensor=$temperature_info_sensor temperature=$temperature_info_value"
         done
+    else
+        echo "Temperature not supported on this platform"
     fi
 }
 

--- a/plugins/edgeos.sh
+++ b/plugins/edgeos.sh
@@ -85,13 +85,15 @@ edgeos_interfaces() {
 edgeos_power() {
     power_info=$(sudo /usr/sbin/ubnt-hal getPowerStatus)
 
-    if ! echo "$power_info" | grep "is not supported on this platform"; then
+    if ! echo "$power_info" | grep -q "is not supported on this platform"; then
         echo "$power_info" | while read -r line; do
             power_info_measurement=$(echo "$line" | cut -d ':' -f 1 | rev | cut -d ' ' -f 1 | rev)
             power_info_value=$(echo "$line" | cut -d ':' -f 2 | cut -d ' ' -f 2)
 
             echo "edgeos_power $power_info_measurement=$power_info_value"
         done
+    else
+        echo "Power status is not supported on this platform"
     fi
 }
 

--- a/plugins/edgeos.sh
+++ b/plugins/edgeos.sh
@@ -93,7 +93,7 @@ edgeos_power() {
             echo "edgeos_power $power_info_measurement=$power_info_value"
         done
     else
-        echo "Power status is not supported on this platform"
+        echo "Collecting power metrics is not supported on this hardware!"
     fi
 }
 
@@ -108,7 +108,7 @@ edgeos_temperature() {
             echo "edgeos_temperature,sensor=$temperature_info_sensor temperature=$temperature_info_value"
         done
     else
-        echo "Temperature not supported on this platform"
+        echo "Collecting temperature metrics is not supported on this hardware!"
     fi
 }
 


### PR DESCRIPTION
An odd issue I noticed on my EdgeRouter X (EdgeOSv2.0.8-hotfix.1): it doesn't support temperature checking, so when I enabled the default config, I assumed that the script would automatically detect that and give a nice error message, like the power monitoring does. Instead, it threw some weird error about a metric parse error. I found two issues:

1. The error message for the temperature is `Temperature not supported on this platform`. Compare that to the one for power: `Power status is not supported on this platform`. Note the lack of "is", which would seem to cause the `grep` call to not function properly for the temperature check. This would be an easy and straightforward fix, except...

2. (this took a while to find) Unlike `getPowerStatus`, `getTemp` will print the error message _itself_, and then return null instead of returning the error message. So checking for a substring never would have worked, because `temperature_info` is empty when there is an error! Gotta love inconsistent code practices. 

Anyway, this PR changes the check condition to check for null instead of checking for a substring. It also adds the error message that gets lost due to the `getTemp` shenanigans, so that the error will show up in Telegraf logs. 

Bonus fix: in the default config, the firmware check uses the interval `1d`, which isn't valid. I changed it to `24h` which is valid and equivalent. 